### PR TITLE
Update MovieDetails score label attribute and its tests

### DIFF
--- a/CineMovie/Scenes/MovieDetails/MovieDetailsViewModel.swift
+++ b/CineMovie/Scenes/MovieDetails/MovieDetailsViewModel.swift
@@ -86,7 +86,7 @@ final class MovieDetailsViewModel {
         let hasScore = movie.voteAverage > 0
         let truncatedScore = String(format: "%.1f", movie.voteAverage)
 
-        return hasScore ? "\(truncatedScore)/10" : Constants.notAvailable
+        return hasScore ? "\(truncatedScore)/10" : String()
     }
 
     // MARK: Methods

--- a/CineMovieTests/Scenes/MovieDetails/MovieDetailsViewModelTests.swift
+++ b/CineMovieTests/Scenes/MovieDetails/MovieDetailsViewModelTests.swift
@@ -285,7 +285,7 @@ final class MovieDetailsViewModelTests: XCTestCase {
         let viewModelScore = viewModelToTest.score
 
         // Then
-        XCTAssertEqual(Constants.notAvailable, viewModelScore)
+        XCTAssertEqual(String(), viewModelScore)
     }
 
     func test_getMovie_shouldCallServiceGetMovie_oneTimeOnly() {


### PR DESCRIPTION
- When the movie doesn't have a score, the UI was having an alignment issue.